### PR TITLE
Allow Google login without requiring privacy consent

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -134,7 +134,7 @@ function AuthModal({ mode, onClose, onAuthenticate, onNavigate, googleClientId }
       return
     }
 
-    if (!formData.consentPrivacy) {
+    if (isRegister && !formData.consentPrivacy) {
       setError('Please acknowledge the privacy policy and GDPR terms to continue.')
       return
     }


### PR DESCRIPTION
## Summary
- only enforce the privacy consent check for Google authentication when registering a new account
- keep the consent error for registration while allowing existing Google users to log in without the modal blocking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbc10f81883329a839b26229f4f32