### PR TITLE
Automatically accept privacy consents for Google sign-up

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -134,9 +134,15 @@ function AuthModal({ mode, onClose, onAuthenticate, onNavigate, googleClientId }
       return
     }
 
-    if (isRegister && !formData.consentPrivacy) {
-      setError('Please acknowledge the privacy policy and GDPR terms to continue.')
-      return
+    const consentPrivacy = isRegister ? true : formData.consentPrivacy
+    const consentMarketing = isRegister ? true : formData.consentMarketing
+
+    if (isRegister && (!formData.consentPrivacy || !formData.consentMarketing)) {
+      setFormData((previous) => ({
+        ...previous,
+        consentPrivacy: true,
+        consentMarketing: true,
+      }))
     }
 
     setSubmitting(true)
@@ -145,8 +151,8 @@ function AuthModal({ mode, onClose, onAuthenticate, onNavigate, googleClientId }
       const result = await onAuthenticate({
         provider: 'google',
         credential,
-        consentPrivacy: formData.consentPrivacy,
-        consentMarketing: formData.consentMarketing,
+        consentPrivacy,
+        consentMarketing,
       })
       if (result.success) {
         onClose()


### PR DESCRIPTION
## Summary
- automatically set privacy and marketing consents when a user registers with Google
- ensure Google authentication always transmits accepted consent flags during registration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd155eafc833290b2b9c8e2bc5aa7