### PR TITLE
Always send variation references as image URLs

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -553,13 +553,13 @@ function getAssetBaseUrl(req) {
   return `${scheme}://${host}`;
 }
 
-async function generateVariationImage({ prompt, imageUrl, base64Fallback }) {
+async function generateVariationImage({ prompt, imageUrl }) {
   const systemInstruction =
     'You are an e-commerce photo retoucher. Use the supplied reference image as the definitive product. Preserve its silhouette, materials, colours, and branding. Only adjust camera angle, lighting, background, or lightweight supporting props. Return exactly one finished square (1:1) image ready for online catalogues.';
 
   const userText = `${prompt}\nUse the provided reference image as the base. Preserve the product's silhouette, materials, colours, and branding. Do not introduce alternative products, new logos, or any text overlays.`;
 
-  const urlMessages = [
+  const messages = [
     {
       role: 'system',
       content: systemInstruction,
@@ -579,44 +579,12 @@ async function generateVariationImage({ prompt, imageUrl, base64Fallback }) {
     },
   ];
 
-  try {
-    const { data } = await openRouterClient.post('/chat/completions', {
-      model: 'google/gemini-2.5-flash-image-preview',
-      messages: urlMessages,
-    });
-    return extractImageFromResponse(data);
-  } catch (error) {
-    if (error.response?.status === 400 && base64Fallback) {
-      console.warn('Variation request failed with image_url; retrying with base64 payload');
-      const base64Messages = [
-        {
-          role: 'system',
-          content: systemInstruction,
-        },
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'text',
-              text: userText,
-            },
-            {
-              type: 'image',
-              image_base64: base64Fallback,
-            },
-          ],
-        },
-      ];
+  const { data } = await openRouterClient.post('/chat/completions', {
+    model: 'google/gemini-2.5-flash-image-preview',
+    messages,
+  });
 
-      const { data } = await openRouterClient.post('/chat/completions', {
-        model: 'google/gemini-2.5-flash-image-preview',
-        messages: base64Messages,
-      });
-      return extractImageFromResponse(data);
-    }
-
-    throw error;
-  }
+  return extractImageFromResponse(data);
 }
 
 function extractImageFromResponse(data) {
@@ -682,14 +650,11 @@ app.post('/api/generate-images', requireAuth, upload.single('image'), async (req
 
     const assetBaseUrl = getAssetBaseUrl(req);
     const imageUrl = `${assetBaseUrl}/uploads/${req.file.filename}`;
-    const base64Fallback = await fsp.readFile(req.file.path, { encoding: 'base64' });
-
     const images = await Promise.all(
       variationRequests.map(async ({ prompt }, index) => {
         const rawImage = await generateVariationImage({
           prompt: `Variation ${index + 1}: ${prompt}`,
           imageUrl,
-          base64Fallback,
         });
         return convertToSquareDataUri(rawImage);
       })


### PR DESCRIPTION
## Summary
- simplify the variation request workflow to always attach the uploaded image via `image_url`
- remove base64 fallbacks and retry logic so nanobanana always receives the hosted asset link

## Testing
- npm test -- --runTestsByPath tests/auth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dbecd32ec88332874c102a7fe6c411