### PR TITLE
Normalize Supabase session fields for library images

### DIFF
--- a/server/src/storage.js
+++ b/server/src/storage.js
@@ -90,38 +90,55 @@ function mapSupabaseSession(row) {
     return fallback;
   };
 
-  return {
+  const coalesce = (...keys) => {
+    for (const key of keys) {
+      if (key in row && row[key] !== undefined && row[key] !== null) {
+        return row[key];
+      }
+    }
+    return undefined;
+  };
+
+  const rawCreator = coalesce('creator', 'creator_info');
+  const normalized = {
     ...row,
-    prompts: parse(row.prompts, []),
-    generatedImages: parse(row.generatedImages, []),
-    descriptions: parse(row.descriptions, []),
-    promptSummaries: parse(row.promptSummaries, []),
-    creator: (() => {
-      const raw = row.creator || null;
-      if (!raw) {
+    id: row.id || row.session_id || null,
+    userId: coalesce('userId', 'user_id') || null,
+    createdAt: coalesce('createdAt', 'created_at') || null,
+    sourceImage: coalesce('sourceImage', 'source_image') || '',
+    prompts: parse(coalesce('prompts', 'prompt_ids'), []),
+    generatedImages: parse(coalesce('generatedImages', 'generated_images'), []),
+    descriptions: parse(coalesce('descriptions', 'description_entries', 'description'), []),
+    promptSummaries: parse(coalesce('promptSummaries', 'prompt_summaries'), []),
+    categories: parse(coalesce('categories', 'category_scopes'), []),
+  };
+
+  normalized.creator = (() => {
+    const raw = rawCreator || null;
+    if (!raw) {
+      return null;
+    }
+    if (typeof raw === 'string') {
+      try {
+        const parsed = JSON.parse(raw);
+        return {
+          id: parsed?.id || null,
+          name: parsed?.name || '',
+        };
+      } catch (_error) {
         return null;
       }
-      if (typeof raw === 'string') {
-        try {
-          const parsed = JSON.parse(raw);
-          return {
-            id: parsed?.id || null,
-            name: parsed?.name || '',
-          };
-        } catch (_error) {
-          return null;
-        }
-      }
-      if (typeof raw === 'object') {
-        return {
-          id: raw.id || null,
-          name: raw.name || '',
-        };
-      }
-      return null;
-    })(),
-    categories: parse(row.categories, []),
-  };
+    }
+    if (typeof raw === 'object') {
+      return {
+        id: raw.id || null,
+        name: raw.name || '',
+      };
+    }
+    return null;
+  })();
+
+  return normalized;
 }
 
 function mapSessionForSupabase(session) {

--- a/server/tests/storage.test.js
+++ b/server/tests/storage.test.js
@@ -77,6 +77,33 @@ describe('mapSupabaseSession', () => {
       creator: { id: 'user-1', name: 'Jane' },
     });
   });
+
+  it('maps snake_case columns from Supabase responses', () => {
+    const mapped = mapSupabaseSession({
+      session_id: 'session-3',
+      user_id: 'user-9',
+      created_at: '2024-01-01T00:00:00.000Z',
+      prompts: '["p-9"]',
+      generated_images: '["img-9"]',
+      description_entries: '["desc-9"]',
+      prompt_summaries: '["summary-9"]',
+      category_scopes: '["apparel"]',
+      source_image: 'https://example.com/source.png',
+      creator_info: '{"id":"user-9","name":"Casey"}',
+    });
+
+    expect(mapped).toMatchObject({
+      id: 'session-3',
+      userId: 'user-9',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      generatedImages: ['img-9'],
+      descriptions: ['desc-9'],
+      promptSummaries: ['summary-9'],
+      categories: ['apparel'],
+      sourceImage: 'https://example.com/source.png',
+      creator: { id: 'user-9', name: 'Casey' },
+    });
+  });
 });
 
 describe('mapSessionForSupabase', () => {


### PR DESCRIPTION
## Summary
- update Supabase session mapping to coalesce camelCase and snake_case columns so generated images and metadata load correctly
- normalize creator, timestamps, and other fields when hydrating sessions
- cover the new mapping behaviour with a Jest test for snake_case Supabase responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbecf176e88332afaf4f2a4ed740c3