### PR TITLE
Fix Google sign-in script initialization to prevent white screen

### DIFF
--- a/client/src/components/GoogleSignInButton.jsx
+++ b/client/src/components/GoogleSignInButton.jsx
@@ -1,29 +1,67 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const GOOGLE_SCRIPT_SRC = 'https://accounts.google.com/gsi/client'
 
-function loadGoogleScript(onLoad) {
-  if (window.google && window.google.accounts?.id) {
+function loadGoogleScript({ onLoad, onError }) {
+  if (window.google?.accounts?.id) {
     onLoad()
-    return
+    return () => {}
   }
 
-  const existingScript = document.querySelector(`script[src="${GOOGLE_SCRIPT_SRC}"]`)
-  if (existingScript) {
-    existingScript.addEventListener('load', onLoad)
-    return
+  let script = document.querySelector(`script[src="${GOOGLE_SCRIPT_SRC}"]`)
+
+  const cleanup = () => {
+    script?.removeEventListener('load', handleLoad)
+    script?.removeEventListener('error', handleError)
   }
 
-  const script = document.createElement('script')
-  script.src = GOOGLE_SCRIPT_SRC
-  script.async = true
-  script.defer = true
-  script.onload = onLoad
-  document.head.appendChild(script)
+  const handleLoad = () => {
+    cleanup()
+    if (script) {
+      script.dataset.googleIdentityState = 'loaded'
+    }
+    onLoad()
+  }
+
+  const handleError = () => {
+    cleanup()
+    if (script) {
+      script.dataset.googleIdentityState = 'error'
+    }
+    onError?.()
+  }
+
+  if (script) {
+    if (script.dataset.googleIdentityState === 'loaded') {
+      onLoad()
+      return () => {}
+    }
+    if (script.dataset.googleIdentityState === 'error') {
+      onError?.()
+      return () => {}
+    }
+  } else {
+    script = document.createElement('script')
+    script.src = GOOGLE_SCRIPT_SRC
+    script.async = true
+    script.defer = true
+    script.dataset.googleIdentityState = 'pending'
+    document.head.appendChild(script)
+  }
+
+  if (!script.dataset.googleIdentityState) {
+    script.dataset.googleIdentityState = 'pending'
+  }
+
+  script.addEventListener('load', handleLoad)
+  script.addEventListener('error', handleError)
+
+  return cleanup
 }
 
 export default function GoogleSignInButton({ clientId, onCredential, text = 'Continue with Google' }) {
   const buttonRef = useRef(null)
+  const [loadError, setLoadError] = useState(false)
 
   useEffect(() => {
     if (!clientId || !buttonRef.current) {
@@ -31,35 +69,57 @@ export default function GoogleSignInButton({ clientId, onCredential, text = 'Con
     }
 
     let cancelled = false
+    let detachListener = () => {}
 
-    loadGoogleScript(() => {
-      if (cancelled) return
-      if (!window.google?.accounts?.id) return
+    detachListener = loadGoogleScript({
+      onLoad: () => {
+        if (cancelled) return
+        if (!window.google?.accounts?.id) return
 
-      window.google.accounts.id.initialize({
-        client_id: clientId,
-        callback: (response) => {
-          if (response?.credential) {
-            onCredential(response.credential)
-          }
-        },
-      })
+        setLoadError(false)
 
-      window.google.accounts.id.renderButton(buttonRef.current, {
-        theme: 'outline',
-        size: 'large',
-        width: '100%',
-        text: 'signin_with',
-        shape: 'pill',
-      })
+        window.google.accounts.id.initialize({
+          client_id: clientId,
+          callback: (response) => {
+            if (response?.credential) {
+              onCredential(response.credential)
+            }
+          },
+          ux_mode: 'popup',
+          auto_select: false,
+          cancel_on_tap_outside: true,
+        })
+
+        if (!buttonRef.current) {
+          return
+        }
+
+        buttonRef.current.innerHTML = ''
+
+        window.google.accounts.id.renderButton(buttonRef.current, {
+          theme: 'outline',
+          size: 'large',
+          text: 'signin_with',
+          type: 'standard',
+          shape: 'pill',
+        })
+      },
+      onError: () => {
+        if (cancelled) return
+        setLoadError(true)
+      },
     })
 
     return () => {
       cancelled = true
+      detachListener?.()
+      if (window.google?.accounts?.id) {
+        window.google.accounts.id.cancel()
+      }
     }
   }, [clientId, onCredential])
 
-  if (!clientId) {
+  if (!clientId || loadError) {
     return (
       <button type="button" className="google-button" onClick={() => onCredential(null)}>
         {text}


### PR DESCRIPTION
## Summary
- harden the Google Identity script loader to reuse existing scripts and surface load failures
- render the Google button after explicitly configuring popup mode and cancel handlers to avoid white screens
- fall back to the manual button when the script cannot be loaded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbee0f82f88332ab4b80a6aef1a50e