### PR TITLE
Require explicit privacy consent for Google sign-up

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -134,16 +134,13 @@ function AuthModal({ mode, onClose, onAuthenticate, onNavigate, googleClientId }
       return
     }
 
-    const consentPrivacy = isRegister ? true : formData.consentPrivacy
-    const consentMarketing = isRegister ? true : formData.consentMarketing
-
-    if (isRegister && (!formData.consentPrivacy || !formData.consentMarketing)) {
-      setFormData((previous) => ({
-        ...previous,
-        consentPrivacy: true,
-        consentMarketing: true,
-      }))
+    if (isRegister && !formData.consentPrivacy) {
+      setError('Please acknowledge the privacy policy and GDPR terms to continue.')
+      return
     }
+
+    const consentPrivacy = Boolean(formData.consentPrivacy)
+    const consentMarketing = Boolean(formData.consentMarketing)
 
     setSubmitting(true)
     setError('')


### PR DESCRIPTION
## Summary
- prevent Google sign-ups from auto-enabling privacy consent so users must acknowledge the policy themselves
- keep the marketing opt-in flag aligned with the user's selection instead of forcing it on during Google registration

## Testing
- npm test --silent
- npm run lint --silent

------
https://chatgpt.com/codex/tasks/task_e_68dbf1dd85288332a705efb64bdb3a2d